### PR TITLE
refactor(app): import 'reflect-metadata'

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,6 +1,4 @@
-import reflectMetadata = require("reflect-metadata");
-var dummy = reflectMetadata; //trigger module import
-
+import 'reflect-metadata';
 import {Component, View} from 'angular2/angular2';
 import {bootstrap} from 'dom/application';
 


### PR DESCRIPTION
I do this on the server for isomorphic angular2 since it compiles down to (at least for TypeScript v1.5.0-beta)

``` es6
require("reflect-metadata");
```
